### PR TITLE
Ensure unique attribute checking works for naive models.

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -357,7 +357,8 @@ Database.prototype.update = function(collectionName, options, values, cb) {
 
   // Get a list of any attributes we're updating that have uniqueness constraints
   var uniqueAttrs = _.where(_.keys(values), function(attrName) {
-    return self.schema[filePath][name][attrName].unique;
+    var attr = self.schema[filePath][name][attrName];
+    return attr ? attr.unique : false;
   });
 
   // If we're updating any attributes that are supposed to be unique, do some additional checks


### PR DESCRIPTION
When attempting to use the associations branch and following the steps taken in the example video, i.e. creating a new app, adding a user model/api, creating a few new users from the browser, and then attempting to update a user record to add in an email address to a user, the update would crash, and the update would be ignored.

This pull request modifies the previous 'unique' flag checking slightly.  It checks to see if there's an attribute definition first before checking to see whether it's has the unique flag set.  This fixes the bug.
