### PR TITLE
Fix data initialization from tmp file

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -59,7 +59,7 @@ Database.prototype.initialize = function(cb) {
   async.auto({
 
     checkData: function(next) {
-      if(self.data) return next();
+      if(Object.keys(self.data).length > 0) return next();
       self.read(next);
     },
 
@@ -102,7 +102,9 @@ Database.prototype.setCollection = function(collectionName, options, cb) {
   if(!this.filePath) return cb(new Error('No filePath was configured for this collection'));
 
   // Set Defaults
-  var data = this.data[collectionName] = options.data || [];
+  var data = this.data[collectionName];
+  data.concat(options.data || []);
+
   var counters = this.counters[collectionName] = options.counters || {};
 
   if(options.definition) options.definition = _.cloneDeep(options.definition);


### PR DESCRIPTION
Fixes an issue with data persisted to the sails-disk tmp not loaded into `Database.data`, making it impossible to retrieve records stored in a previous run of sails.
