### PR TITLE
Fix iteration bugs if the environment has Array polyfill

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -206,6 +206,10 @@ Database.prototype.read = function(cb) {
 
   // Cast values when reading off of disk.  Essentially, unserialize the records.
   for (var collectionName in state.data) {
+    if (!state.data.hasOwnProperty(collectionName)) {
+      continue;
+    }
+
     state.data[collectionName].map(function (values) {
       if (self.collections[collectionName]) {
         self.collections[collectionName]._cast.run(values);
@@ -352,6 +356,10 @@ Database.prototype.insert = function(collectionName, values, cb) {
   // Iterate over each record being inserted, deal w/ auto-incrementing
   // and checking the uniquness constraints.
   for (var i in values) {
+    if (!values.hasOwnProperty(i)) {
+      continue;
+    }
+
     var record = values[i];
 
     // Check Uniqueness Constraints
@@ -464,6 +472,10 @@ Database.prototype.update = function(collectionName, options, values, cb) {
   // Build up final set of results.
   var results = [];
   for (var i in resultSet.indices) {
+    if (!resultSet.indices.hasOwnProperty(i)) {
+      continue;
+    }
+
     var matchIndex = resultSet.indices[i];
     var _values = self.data[collectionName][matchIndex];
 
@@ -522,6 +534,10 @@ Database.prototype.destroy = function(collectionName, options, cb) {
 Database.prototype.autoIncrement = function(collectionName, values) {
 
   for (var attrName in this.schema[collectionName]) {
+    if (!this.schema[collectionName].hasOwnProperty(attrName)) {
+      continue;
+    }
+
     var attrDef = this.schema[collectionName][attrName];
 
     // Only apply autoIncrement if we're supposed to!
@@ -616,12 +632,19 @@ Database.prototype.enforceUniqueness = function(collectionName, values, pkValueO
   var pkAttrName = getPrimaryKey(this.schema[collectionName]);
 
   for (var attrName in this.schema[collectionName]) {
+    if (!this.schema.hasOwnProperty(attrName)) {
+      continue;
+    }
+
     var attrDef = this.schema[collectionName][attrName];
 
     if(!attrDef.unique) continue;
 
     // Loop through each record in our database
     for (var index in this.data[collectionName]) {
+      if (!this.data[collectionName].hasOwnProperty(index)) {
+        continue;
+      }
 
       // Ignore uniqueness check on undefined values
       // (they shouldn't have been stored anyway)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails-disk",
-  "version": "0.10.10",
+  "version": "0.11.0",
   "description": "Persistent local-disk adapter for Sails.js / Waterline",
   "main": "lib/adapter.js",
   "scripts": {
@@ -23,6 +23,9 @@
   "contributors": [
     {
       "name": "Cody Stoltman"
+    },
+    {
+      "name": "Michael Smyers"
     }
   ],
   "license": "MIT",


### PR DESCRIPTION
If the node environment has any polyfill for Arrays, the database becomes corrupted with many null values.
